### PR TITLE
package bundler - to match require

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,6 +305,10 @@ class redmine (
   # set up database
   include "redmine::${redmine::db_type}"
 
+  package { 'bundler':
+    ensure   => 'present',
+    provider => 'gem',
+  }
   exec { 'Install gems using bundler':
     command     => "bundle install --path ${redmine::user_home}/.gem",
     user        => $redmine::user,


### PR DESCRIPTION
The 'Install gems using bundler' `exec` resource has `require => Package['bundler'],` but must have a matching `package` statement for bundler.